### PR TITLE
rename project to NZ - fixes #1

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,23 +1,23 @@
-# NZUG Development Context
+# NZ Development Context
 
 This document captures the design decisions, open questions, and key references for the
-**NZUG (NetCDF-Zarr Users Guide)** convention. It is intended to orient contributors and
+**NZ (NetCDF-Zarr)** convention. It is intended to orient contributors and
 to resume working sessions without re-deriving settled conclusions. This content was 
 generated to document and iterative development process using Claude Opus 4.6.
 
 ---
 
-## What NZUG Is
+## What NZ Is
 
-NZUG is a Zarr convention that provides the same structural role for the Zarr ecosystem
+NZ is a Zarr convention that provides the same structural role for the Zarr ecosystem
 that the format definition parts of the [NetCDF Users Guide (NUG)](https://docs.unidata.ucar.edu/nug/current/) provides
 for netCDF. It defines the minimum set of constraints above the Zarr v3 spec — structural
 vocabulary, a typed data model, naming rules, and reserved attributes — that allows domain
 conventions (primarily CF) to operate on Zarr data without modification to those domain
 conventions.
 
-**The single most important framing:** NZUG allows CF to be applied to Zarr by substituting
-"NZUG array" for "NUG variable" and "NZUG hierarchy" for "netCDF file" throughout the CF
+**The single most important framing:** NZ allows CF to be applied to Zarr by substituting
+"NZ array" for "NUG variable" and "NZ hierarchy" for "netCDF file" throughout the CF
 spec. No changes to CF are required.
 
 ---
@@ -26,15 +26,15 @@ spec. No changes to CF are required.
 
 | Resource                              | URL                                                             | Role                                                           |
 | ------------------------------------- | --------------------------------------------------------------- | -------------------------------------------------------------- |
-| Zarr v3 specification                 | https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html   | Format spec NZUG builds on                                     |
-| zarr-conventions-spec                 | https://github.com/zarr-conventions/zarr-conventions-spec       | Framework NZUG registers within                                |
+| Zarr v3 specification                 | https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html   | Format spec NZ builds on                                     |
+| zarr-conventions-spec                 | https://github.com/zarr-conventions/zarr-conventions-spec       | Framework NZ registers within                                |
 | zarr-conventions org                  | https://github.com/zarr-conventions                             | Home for registered conventions                                |
-| NetCDF Users Guide                    | https://docs.unidata.ucar.edu/nug/current/                      | Structural analogue NZUG replaces                              |
-| CF Metadata Conventions               | https://cfconventions.org/                                      | Primary domain convention NZUG enables                         |
+| NetCDF Users Guide                    | https://docs.unidata.ucar.edu/nug/current/                      | Structural analogue NZ replaces                              |
+| CF Metadata Conventions               | https://cfconventions.org/                                      | Primary domain convention NZ enables                         |
 | NCZarr documentation                  | https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html | Unidata's existing netCDF-C Zarr backend; related but distinct |
-| GeoZarr spec                          | https://github.com/zarr-developers/geozarr-spec                 | Higher-level convention; NZUG is explicitly out of its scope   |
-| CF conventions discussion #463        | https://github.com/orgs/cf-convention/discussions/463           | CF community thread that motivated NZUG                        |
-| zarr-developers discussion #76        | https://github.com/orgs/zarr-developers/discussions/76          | NZUG proposal thread in zarr-developers                        |
+| GeoZarr spec                          | https://github.com/zarr-developers/geozarr-spec                 | Higher-level convention; NZ is explicitly out of its scope   |
+| CF conventions discussion #463        | https://github.com/orgs/cf-convention/discussions/463           | CF community thread that motivated NZ                        |
+| zarr-developers discussion #76        | https://github.com/orgs/zarr-developers/discussions/76          | NZ proposal thread in zarr-developers                        |
 | zarr-specs consolidated metadata #309 | https://github.com/zarr-developers/zarr-specs/issues/309        | Tracks formal standardization of consolidated metadata         |
 
 ---
@@ -43,17 +43,16 @@ spec. No changes to CF are required.
 
 ### Convention name and declaration
 
-- Convention identifier is **`NZUG-1.0`** (previously explored as `NZarr-1.0`; name still
-  subject to community input but the identifier format is settled).
-- Declaration via `"conventions": "NZUG-1.0"` in root group `attributes`. Space-separated
-  for multi-convention datasets: `"conventions": "NZUG-1.0 CF-1.12"`.
+- Convention identifier is **`NZ-1.0`** (previously explored as `NZarr-1.0` and `NZUG-1.0`; name still subject to community input but the identifier format is settled).
+- Declaration via `"conventions": "NZ-1.0"` in root group `attributes`. Space-separated
+  for multi-convention datasets: `"conventions": "NZ-1.0 CF-1.12"`.
 - `Conventions` (capital C, NUG legacy) treated as equivalent to `conventions` during reading.
 - A `zarr_conventions` CMO entry (per zarr-conventions-spec framework) is optional but
   recommended. See Appendix C of the spec for the registration object template.
 
 ### Zarr v3 as baseline
 
-NZUG is written against **Zarr v3**, not v2. Key v3 features that motivated this:
+NZ is written against **Zarr v3**, not v2. Key v3 features that motivated this:
 
 - `dimension_names` is a first-class field in `zarr.json` (promoted from xarray's
   `_ARRAY_DIMENSIONS` attribute convention).
@@ -84,22 +83,22 @@ to a SHOULD or reframed as informative.
 ### Attribute namespacing
 
 The zarr-conventions-spec SHOULD (not MUST) use namespace prefixes or nesting to avoid
-collisions. NZUG uses flat unprefixed attributes by design, for two reasons:
+collisions. NZ uses flat unprefixed attributes by design, for two reasons:
 
 1. These attribute names (`_FillValue`, `scale_factor`, `coordinates`, etc.) already have
    de facto ecosystem-wide meaning — xarray, netCDF-python, and CF tools read them from
    Zarr `attributes` today. Prefixing would break all existing tooling.
-2. NZUG occupies the structural substrate tier, not the domain-convention tier that the
+2. NZ occupies the structural substrate tier, not the domain-convention tier that the
    namespacing guidance targets. The analogy: `zarr_format` and `node_type` are also
    unprefixed structural fields.
 
 **Exception flagged:** `_type` is novel (no existing ecosystem precedent) and could
-reasonably take a prefix (e.g., `nzug:type`) without breaking anything. This remains open
+reasonably take a prefix (e.g., `nz:type`) without breaking anything. This remains open
 for community input.
 
 ### Separation of concerns — what is explicitly out of scope
 
-This scoping is load-bearing. NZUG does not take positions on:
+This scoping is load-bearing. NZ does not take positions on:
 
 - Coordinate reference systems and CRS encoding (GeoZarr, CF `grid_mapping`)
 - Axis order and its relationship to CRS definitions
@@ -112,23 +111,23 @@ This scoping is load-bearing. NZUG does not take positions on:
 - User-defined types (enums, compounds)
 - Aggregation / virtual datasets (Kerchunk, Icechunk)
 
-The intent: NZUG can be ratified independently of the active GeoZarr and CF-Zarr debates.
-Progress on those debates does not block NZUG, and NZUG ratification does not prejudice them.
+The intent: NZ can be ratified independently of the active GeoZarr and CF-Zarr debates.
+Progress on those debates does not block NZ, and NZ ratification does not prejudice them.
 
 ### Consolidated metadata
 
-NZUG RECOMMENDS (not requires) consolidated metadata for object storage datasets, following
+NZ RECOMMENDS (not requires) consolidated metadata for object storage datasets, following
 the zarr-python convention (stored under `consolidated_metadata` in root `zarr.json`).
 Will be upgraded to MUST when zarr-specs #309 is finalized.
 
 ---
 
-## The NUG → NZUG Substitution Table
+## The NUG → NZ Substitution Table
 
-This table is the core deliverable. A CF-Zarr profile document cites NZUG and performs
+This table is the core deliverable. A CF-Zarr profile document cites NZ and performs
 these substitutions; the CF spec itself is unchanged.
 
-| NUG concept                        | NZUG equivalent                                                                |
+| NUG concept                        | NZ equivalent                                                                |
 | ---------------------------------- | ------------------------------------------------------------------------------ |
 | netCDF file                        | Zarr v3 hierarchy                                                              |
 | dimension                          | dimension label in `dimension_names` + shared dimension constraint             |
@@ -144,10 +143,10 @@ these substitutions; the CF spec itself is unchanged.
 
 ## Open Questions
 
-- **Convention name:** `NZUG-1.0` vs `NZarr-1.0` vs something else. The zarr-conventions-spec
+- **Convention name:** `NZ-1.0` vs `NZUG-1.0` vs `NZarr-1.0` vs something else. The zarr-conventions-spec
   uses UUID as primary identifier so the string name matters less for machine identification,
   but matters for human legibility and citation.
-- **`_type` namespacing:** Should `_type` take a prefix (`nzug:type`) given it is novel and
+- **`_type` namespacing:** Should `_type` take a prefix (`nz:type`) given it is novel and
   has no legacy tooling to break?
 - **Scalar arrays:** Soften to SHOULD or drop from normative content entirely and move to
   informative?
@@ -163,6 +162,6 @@ these substitutions; the CF spec itself is unchanged.
 
 NCZarr is Unidata's implementation of netCDF-C on top of Zarr. It solves some of the same
 problems (shared dimensions via `.nczgroup`, coordinate variables) but is tied to the
-netCDF-C library and its `.nczarr` metadata extensions. NZUG is not NCZarr: it is a
+netCDF-C library and its `.nczarr` metadata extensions. NZ is not NCZarr: it is a
 community convention that any implementation can adopt, defined wholly on top of the Zarr
 v3 spec without netCDF-C library dependencies.

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# NZUG-1.0 NetCDF - Zarr Users Guide
+# NZ-1.0 NetCDF - Zarr Convention
 
 - **UUID**: d0a980b5-c644-4dcc-85a1-283799a58f40
-- **Name**: NZUG-1.0
-- **Schema URL**: "https://github.com/zarr-conventions/nzug/blob/v1-proposed/schema.json"
-- **Spec URL**: "https://github.com/zarr-conventions/nzug/blob/v1-proposed/README.md"
+- **Name**: NZ-1.0
+- **Schema URL**: "https://github.com/zarr-conventions/nz/blob/v1-proposed/schema.json"
+- **Spec URL**: "https://github.com/zarr-conventions/nz/blob/v1-proposed/README.md"
 - **Scope**: Array, Group
 - **Extension Maturity Classification**: Proposal
 - **Owner**: @dblodgett-usgs
 
 ## Description
 
-NZUG-1.0 (NetCDF Zarr Users Guide) is a Zarr convention that defines a structural interoperability layer for array-oriented scientific data on top of the [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html). It serves the same structural role for the Zarr ecosystem that the [NetCDF Users Guide (NUG)](https://docs.unidata.ucar.edu/nug/current/) serves for netCDF: it defines a shared vocabulary of structural concepts, a typed data model, naming rules, and a small set of reserved attributes that domain conventions can be written against without modification.
+NZ-1.0 (NetCDF Zarr convention) is a Zarr convention that defines a structural interoperability layer for array-oriented scientific data on top of the [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html). It serves the same structural role for the Zarr ecosystem that the [NetCDF Users Guide (NUG)](https://docs.unidata.ucar.edu/nug/current/) serves for netCDF: it defines a shared vocabulary of structural concepts, a typed data model, naming rules, and a small set of reserved attributes that domain conventions can be written against without modification.
 
 The primary design goal is to allow existing domain conventions — in particular the [CF Metadata Conventions](https://cfconventions.org/) — to be applied to Zarr v3 datasets by replacing the NUG as the underlying structural reference, **with no changes required to the domain convention itself.**
 
-NZUG-1.0 is not a geospatial convention, not a CF extension, and not a replacement for the Zarr v3 specification. It is the structural layer between the format specification and domain conventions.
+NZ-1.0 is not a geospatial convention, not a CF extension, and not a replacement for the Zarr v3 specification. It is the structural layer between the format specification and domain conventions.
 
 All properties use standard attribute names (not namespaced) and are placed at the root `attributes` level following the [Zarr Conventions Specification](https://github.com/zarr-conventions/zarr-conventions-spec).
 
-> This document proposes NZUG-1.0 as a Zarr convention. The keywords **MUST**, **MUST NOT**,
+> This document proposes NZ-1.0 as a Zarr convention. The keywords **MUST**, **MUST NOT**,
 > **REQUIRED**, **SHALL**, **SHALL NOT**, **SHOULD**, **SHOULD NOT**, **RECOMMENDED**, **MAY**,
 > and **OPTIONAL** in this document are to be interpreted as described in
 > [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 >
-> All normative text is marked with the label **\[NZUG addition\]** where it adds constraints
+> All normative text is marked with the label **\[NZ addition\]** where it adds constraints
 > above the [Zarr v3 specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html).
 > All other content is either a restatement of v3 content for clarity or informative.
 
@@ -37,14 +37,14 @@ All properties use standard attribute names (not namespaced) and are placed at t
 
 ## Motivation
 
-- **Interoperability layer gap**: Domain conventions for scientific array data (like CF) are written against a format specification that provides structural primitives — named dimensions, typed variables, typed attributes, named coordinate systems. The Zarr v3 specification defines a capable storage model but deliberately leaves these structural refinements to conventions. NZUG fills that gap.
-- **Domain convention adoption**: By providing NUG-equivalent structural concepts, NZUG allows domain conventions written against the NUG — such as CF — to be applied to Zarr using a simple reference substitution (NUG → NZUG), without waiting for geospatial convention debates to resolve.
-- **Stable foundation for domain conventions**: GeoZarr, OME-NGFF, and related conventions can build on NZUG rather than independently re-solving the same structural problems.
+- **Interoperability layer gap**: Domain conventions for scientific array data (like CF) are written against a format specification that provides structural primitives — named dimensions, typed variables, typed attributes, named coordinate systems. The Zarr v3 specification defines a capable storage model but deliberately leaves these structural refinements to conventions. NZ fills that gap.
+- **Domain convention adoption**: By providing NUG-equivalent structural concepts, NZ allows domain conventions written against the NUG — such as CF — to be applied to Zarr using a simple reference substitution (NUG → NZ), without waiting for geospatial convention debates to resolve.
+- **Stable foundation for domain conventions**: GeoZarr, OME-NGFF, and related conventions can build on NZ rather than independently re-solving the same structural problems.
 - **Implementation convergence**: Implementations can converge on shared structural behavior before domain-level semantics are fully standardized.
 
 ### Separation of Concerns
 
-NZUG-1.0 is explicitly scoped to the structural interoperability layer. The following are **out of scope** and left to conventions that build on NZUG:
+NZ-1.0 is explicitly scoped to the structural interoperability layer. The following are **out of scope** and left to conventions that build on NZ:
 
 - Coordinate reference systems and geospatial metadata
 - Standard names, units vocabularies, and physical quantity identification
@@ -54,23 +54,23 @@ NZUG-1.0 is explicitly scoped to the structural interoperability layer. The foll
 - Multi-scale, tiled, or pyramidal data structures
 - Any other domain-specific semantic content
 
-**This scoping is intentional and load-bearing.** The geospatial and Earth science communities are actively debating CRS encoding, axis order, coordinate role identification, and related questions. NZUG does not enter those debates. It provides the structural floor on which they can be settled independently.
+**This scoping is intentional and load-bearing.** The geospatial and Earth science communities are actively debating CRS encoding, axis order, coordinate role identification, and related questions. NZ does not enter those debates. It provides the structural floor on which they can be settled independently.
 
 ### Relationship to the Zarr v3 Specification
 
-NZUG-1.0 adds normative constraints and definitions above the Zarr v3 specification. It does not modify or contradict the Zarr v3 spec. Every valid NZUG-1.0 dataset is a valid Zarr v3 dataset. Implementations that support Zarr v3 can read NZUG-1.0 datasets; they will simply not enforce the additional constraints defined here.
+NZ-1.0 adds normative constraints and definitions above the Zarr v3 specification. It does not modify or contradict the Zarr v3 spec. Every valid NZ-1.0 dataset is a valid Zarr v3 dataset. Implementations that support Zarr v3 can read NZ-1.0 datasets; they will simply not enforce the additional constraints defined here.
 
 ### Relationship to Zarr v2
 
-NZUG-1.0 is defined against Zarr v3, but its structural concepts have direct analogues in Zarr v2 datasets. Many v2 datasets already follow the patterns NZUG formalizes: xarray writes dimension names via the `_ARRAY_DIMENSIONS` attribute in `.zattrs`, NCZarr writes attribute type annotations via `_nczarr_attr` in `.zattrs`, and `_FillValue` and `conventions` are widely used. A Zarr v2 dataset that follows these existing practices is structurally equivalent to a NZUG-1.0 dataset, differing only in the metadata container (`.zattrs` / `.zarray` vs unified `zarr.json`) and the dimension name mechanism (`_ARRAY_DIMENSIONS` attribute vs `dimension_names` field). NZUG-1.0 does not define a v2 profile, but implementations that support both format versions MAY apply NZUG-1.0 structural semantics to v2 datasets that use these established patterns.
+NZ-1.0 is defined against Zarr v3, but its structural concepts have direct analogues in Zarr v2 datasets. Many v2 datasets already follow the patterns NZ formalizes: xarray writes dimension names via the `_ARRAY_DIMENSIONS` attribute in `.zattrs`, NCZarr writes attribute type annotations via `_nczarr_attr` in `.zattrs`, and `_FillValue` and `conventions` are widely used. A Zarr v2 dataset that follows these existing practices is structurally equivalent to a NZ-1.0 dataset, differing only in the metadata container (`.zattrs` / `.zarray` vs unified `zarr.json`) and the dimension name mechanism (`_ARRAY_DIMENSIONS` attribute vs `dimension_names` field). NZ-1.0 does not define a v2 profile, but implementations that support both format versions MAY apply NZ-1.0 structural semantics to v2 datasets that use these established patterns.
 
 ### Relationship to Domain Conventions
 
-A domain convention is a document that specifies semantics for datasets built on a structural interoperability layer. The CF Metadata Conventions are the primary domain convention this document is designed to support. NZUG-1.0 provides to a CF-Zarr profile exactly what the NUG provides to CF-netCDF.
+A domain convention is a document that specifies semantics for datasets built on a structural interoperability layer. The CF Metadata Conventions are the primary domain convention this document is designed to support. NZ-1.0 provides to a CF-Zarr profile exactly what the NUG provides to CF-netCDF.
 
-Domain conventions built on NZUG-1.0 MUST declare compliance using the `conventions` attribute defined in [Convention Declaration](#convention-declaration). They MAY add constraints above NZUG-1.0 but MUST NOT contradict it. For backward compatibility, software that supports NetCDF in Zarr are encouraged to try to support data that do not declare compliance with NZUG conventions but do adhere to its assumptions.
+Domain conventions built on NZ-1.0 MUST declare compliance using the `conventions` attribute defined in [Convention Declaration](#convention-declaration). They MAY add constraints above NZ-1.0 but MUST NOT contradict it. For backward compatibility, software that supports NetCDF in Zarr are encouraged to try to support data that do not declare compliance with NZ conventions but do adhere to its assumptions.
 
-The ordering is: Zarr v3 spec → NZUG-1.0 → domain conventions (CF, GeoZarr, etc.).
+The ordering is: Zarr v3 spec → NZ-1.0 → domain conventions (CF, GeoZarr, etc.).
 
 ## Convention Registration
 
@@ -80,10 +80,10 @@ The convention must be registered in `zarr_conventions`:
 {
   "zarr_conventions": [
     {
-      "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-      "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+      "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+      "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
       "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-      "name": "NZUG-1.0",
+      "name": "NZ-1.0",
       "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
     }
   ]
@@ -99,14 +99,14 @@ This convention can be used with these parts of the Zarr hierarchy:
 
 ## Convention Declaration
 
-A dataset is a NZUG-1.0 dataset if its root group `zarr.json` contains `"NZUG-1.0"` in its `conventions` attribute:
+A dataset is a NZ-1.0 dataset if its root group `zarr.json` contains `"NZ-1.0"` in its `conventions` attribute:
 
 ```json
 {
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "conventions": "NZUG-1.0"
+    "conventions": "NZ-1.0"
   }
 }
 ```
@@ -118,14 +118,14 @@ A dataset conforming to multiple conventions lists them space-separated, ordered
   "zarr_format": 3,
   "node_type": "group",
   "attributes": {
-    "conventions": "NZUG-1.0 CF-1.12"
+    "conventions": "NZ-1.0 CF-1.12"
   }
 }
 ```
 
 The `conventions` attribute is case-insensitive for the purpose of matching convention identifiers. The `Conventions` attribute (capital C), used in the NUG, MUST be treated as equivalent to `conventions` during reading for backward compatibility with datasets produced by netCDF toolchains.
 
-> **Note:** NZUG-1.0 uses the `conventions` string attribute at the root group level for declaration. This is consistent with the NUG `Conventions` attribute pattern and with how xarray and existing CF-Zarr tools already use this field. Datasets conforming to the [zarr-conventions-spec](https://github.com/zarr-conventions/zarr-conventions-spec) framework MAY additionally include a `zarr_conventions` entry per that framework.
+> **Note:** NZ-1.0 uses the `conventions` string attribute at the root group level for declaration. This is consistent with the NUG `Conventions` attribute pattern and with how xarray and existing CF-Zarr tools already use this field. Datasets conforming to the [zarr-conventions-spec](https://github.com/zarr-conventions/zarr-conventions-spec) framework MAY additionally include a `zarr_conventions` entry per that framework.
 
 ## Data Model
 
@@ -147,7 +147,7 @@ A _group_ is a node with `"node_type": "group"`. Groups may contain child groups
 
 An _array_ is a node with `"node_type": "array"`. An array has a shape, a data type, a chunk grid, a codec pipeline, a fill value, and optionally dimension names and attributes, all carried in its `zarr.json`.
 
-**\[NZUG addition\]** In a NZUG-1.0 dataset, every array MUST have a fully populated `dimension_names` field. The `dimension_names` array MUST have the same length as `shape`. No entry in `dimension_names` may be `null` or the empty string `""`. The Zarr v3 specification makes `dimension_names` optional; NZUG-1.0 requires it.
+**\[NZ addition\]** In a NZ-1.0 dataset, every array MUST have a fully populated `dimension_names` field. The `dimension_names` array MUST have the same length as `shape`. No entry in `dimension_names` may be `null` or the empty string `""`. The Zarr v3 specification makes `dimension_names` optional; NZ-1.0 requires it.
 
 Example of a minimal compliant array `zarr.json`:
 
@@ -179,13 +179,13 @@ Example of a minimal compliant array `zarr.json`:
 
 A _dimension_ is an axis of an array, identified by its position in `shape` and its corresponding label in `dimension_names`.
 
-**\[NZUG addition\]** Within a group, all arrays that share a dimension label MUST have the same length along that axis. This is the _shared dimension constraint_. It is the Zarr-convention equivalent of the NUG's shared named dimension: a dimension label within a group is not merely a name, it is a constraint on co-extent. Domain conventions may rely on this constraint to define co-location of arrays.
+**\[NZ addition\]** Within a group, all arrays that share a dimension label MUST have the same length along that axis. This is the _shared dimension constraint_. It is the Zarr-convention equivalent of the NUG's shared named dimension: a dimension label within a group is not merely a name, it is a constraint on co-extent. Domain conventions may rely on this constraint to define co-location of arrays.
 
-**\[NZUG addition\]** Dimension labels are scoped to the group containing the array. The same label used in different groups has no required relationship between groups unless a domain convention specifies otherwise.
+**\[NZ addition\]** Dimension labels are scoped to the group containing the array. The same label used in different groups has no required relationship between groups unless a domain convention specifies otherwise.
 
 ### Dimension Coordinate
 
-**\[NZUG addition\]** A _dimension coordinate_ is an array satisfying all of the following:
+**\[NZ addition\]** A _dimension coordinate_ is an array satisfying all of the following:
 
 - It is contained in the same group as the array whose dimension it describes
 - Its `dimension_names` contains exactly one entry
@@ -198,17 +198,17 @@ An array named `lat` with `"dimension_names": ["lat"]` and monotonically ordered
 
 ### Auxiliary Array
 
-An _auxiliary array_ is an array that provides coordinate or ancillary information for another array but does not satisfy the dimension coordinate definition above. How auxiliary arrays are associated with data arrays — including the attribute names and syntax used to declare those relationships — is left to domain conventions (e.g., the `coordinates` attribute used by CF). NZUG-1.0 defines the concept but does not reserve any attribute names for it.
+An _auxiliary array_ is an array that provides coordinate or ancillary information for another array but does not satisfy the dimension coordinate definition above. How auxiliary arrays are associated with data arrays — including the attribute names and syntax used to declare those relationships — is left to domain conventions (e.g., the `coordinates` attribute used by CF). NZ-1.0 defines the concept but does not reserve any attribute names for it.
 
 ### Scalar Array
 
-**\[NZUG addition\]** A _scalar array_ is an array that holds exactly one value. It is encoded in Zarr v3 with `"shape": []` (no dimensions) and `"dimension_names": []`. Despite having no dimensions, a scalar array contains a single typed data value in its chunk store. NZUG-1.0 requires implementations to support scalar arrays.
+**\[NZ addition\]** A _scalar array_ is an array that holds exactly one value. It is encoded in Zarr v3 with `"shape": []` (no dimensions) and `"dimension_names": []`. Despite having no dimensions, a scalar array contains a single typed data value in its chunk store. NZ-1.0 requires implementations to support scalar arrays.
 
 Scalar arrays are used as single-valued coordinate variables — for example, to represent a single pressure level or forecast time without introducing a size-one dimension. They are not a substitute for attributes: a scalar array is a first-class array node with a declared `data_type` and coordinate semantics, not JSON metadata. A naive Zarr v3 reader will read scalar arrays without error.
 
 ## Type System
 
-The NUG's typed attribute model is a load-bearing feature for domain conventions. Precision requirements for numeric attributes — such as packing parameters and CRS coefficients — depend on knowing whether an attribute value is `float32` or `float64`. Zarr v3's JSON attribute model does not provide this distinction. This section defines the NZUG-1.0 type system for attributes.
+The NUG's typed attribute model is a load-bearing feature for domain conventions. Precision requirements for numeric attributes — such as packing parameters and CRS coefficients — depend on knowing whether an attribute value is `float32` or `float64`. Zarr v3's JSON attribute model does not provide this distinction. This section defines the NZ-1.0 type system for attributes.
 
 ### Array Data Types
 
@@ -218,9 +218,9 @@ Array data types are as defined in the Zarr v3 specification. The following name
 
 ### Attribute Value Types
 
-Default type mapping from JSON attribute values to NZUG types:
+Default type mapping from JSON attribute values to NZ types:
 
-| JSON value type       | NZUG default type           |
+| JSON value type       | NZ default type           |
 | --------------------- | --------------------------- |
 | string                | `string`                    |
 | boolean               | `bool`                      |
@@ -231,11 +231,11 @@ Default type mapping from JSON attribute values to NZUG types:
 | array of strings      | `string[]`                  |
 | object                | untyped structured metadata |
 
-Homogeneity is required within JSON arrays used as attribute values. A JSON array containing mixed numeric and string values is not a valid NZUG attribute value.
+Homogeneity is required within JSON arrays used as attribute values. A JSON array containing mixed numeric and string values is not a valid NZ attribute value.
 
 ### Attribute Type Annotation
 
-**\[NZUG addition\]** When a domain convention requires an attribute to be of a specific numeric type that differs from the JSON default, the array or group `zarr.json` MUST include a `_nczarr_attr` attribute. This adopts the attribute type annotation pattern established by [NCZarr](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html) (netCDF-C's Zarr backend), adapted for Zarr v3.
+**\[NZ addition\]** When a domain convention requires an attribute to be of a specific numeric type that differs from the JSON default, the array or group `zarr.json` MUST include a `_nczarr_attr` attribute. This adopts the attribute type annotation pattern established by [NCZarr](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html) (netCDF-C's Zarr backend), adapted for Zarr v3.
 
 The `_nczarr_attr` attribute is a JSON object containing a single key `"types"`, whose value is a JSON object mapping attribute names to type identifiers:
 
@@ -276,29 +276,29 @@ The following table shows the correspondence between Zarr v3 type names and NC t
 | `float32`    | `NC_FLOAT`  |
 | `float64`    | `NC_DOUBLE` |
 
-> **Interoperability note:** Datasets produced by [NCZarr](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html) (netCDF-C's Zarr backend) use [NumPy dtype notation](https://numpy.org/doc/stable/reference/arrays.dtypes.html) (e.g., `<f4` for `float32`) in `_nczarr_attr` type values. NumPy dtype strings are not part of the NZUG-1.0 specification, but implementations are encouraged to recognize them without error to support interoperability with NCZarr-produced datasets.
+> **Interoperability note:** Datasets produced by [NCZarr](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html) (netCDF-C's Zarr backend) use [NumPy dtype notation](https://numpy.org/doc/stable/reference/arrays.dtypes.html) (e.g., `<f4` for `float32`) in `_nczarr_attr` type values. NumPy dtype strings are not part of the NZ-1.0 specification, but implementations are encouraged to recognize them without error to support interoperability with NCZarr-produced datasets.
 
-The `_nczarr_attr` object need not annotate every attribute — only those whose default JSON type is insufficient. Unannotated numeric attributes are interpreted at their JSON default type per [Attribute Value Types](#attribute-value-types). The `_nczarr_attr` attribute is reserved by NZUG-1.0 and MUST NOT be used for other purposes. Implementations SHOULD suppress `_nczarr_attr` from user-visible attribute listings.
+The `_nczarr_attr` object need not annotate every attribute — only those whose default JSON type is insufficient. Unannotated numeric attributes are interpreted at their JSON default type per [Attribute Value Types](#attribute-value-types). The `_nczarr_attr` attribute is reserved by NZ-1.0 and MUST NOT be used for other purposes. Implementations SHOULD suppress `_nczarr_attr` from user-visible attribute listings.
 
-This mechanism is directly interoperable with datasets produced by [netCDF-C's NCZarr backend](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html), which uses the same `_nczarr_attr` / `types` structure in Zarr v2 `.zattr` objects. NZUG-1.0 places this structure in Zarr v3 `zarr.json` `attributes`.
+This mechanism is directly interoperable with datasets produced by [netCDF-C's NCZarr backend](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html), which uses the same `_nczarr_attr` / `types` structure in Zarr v2 `.zattr` objects. NZ-1.0 places this structure in Zarr v3 `zarr.json` `attributes`.
 
 ### The `_FillValue` Attribute
 
-**\[NZUG addition\]** The attribute name `_FillValue` is reserved as the _semantic missing data indicator_. It is distinct from the storage-level `fill_value` field in `zarr.json`, which specifies the value used to initialize unwritten chunks.
+**\[NZ addition\]** The attribute name `_FillValue` is reserved as the _semantic missing data indicator_. It is distinct from the storage-level `fill_value` field in `zarr.json`, which specifies the value used to initialize unwritten chunks.
 
 When `_FillValue` is present in an array's attributes, convention-aware readers MUST treat values equal to `_FillValue` as missing data, regardless of the storage `fill_value`. When both are present and differ, `_FillValue` governs masking semantics. The type of `_FillValue` is determined by the `_nczarr_attr` type annotation if present, or defaults to the array's `data_type`.
 
-This decoupling is necessary because Zarr's storage `fill_value` serves a different purpose (chunk initialization) than the semantic use of `_FillValue` for missing data masking. In netCDF, these happen to be the same mechanism; in Zarr, they are independent. NZUG preserves the NUG's masking semantics by defining `_FillValue` as an attribute with clear precedence over the storage-level field.
+This decoupling is necessary because Zarr's storage `fill_value` serves a different purpose (chunk initialization) than the semantic use of `_FillValue` for missing data masking. In netCDF, these happen to be the same mechanism; in Zarr, they are independent. NZ preserves the NUG's masking semantics by defining `_FillValue` as an attribute with clear precedence over the storage-level field.
 
 ## Properties
 
-NZUG-1.0 uses standard (non-namespaced) attribute names. Only attributes that define or support the structural interoperability layer are reserved here. All domain-level attributes — including those defined by CF (e.g., `units`, `long_name`, `scale_factor`, `add_offset`, `coordinates`, `valid_range`) — are left to domain conventions and are not reserved by NZUG-1.0.
+NZ-1.0 uses standard (non-namespaced) attribute names. Only attributes that define or support the structural interoperability layer are reserved here. All domain-level attributes — including those defined by CF (e.g., `units`, `long_name`, `scale_factor`, `add_offset`, `coordinates`, `valid_range`) — are left to domain conventions and are not reserved by NZ-1.0.
 
 ### Root Group Attributes
 
 | Attribute     | Type   | Obligation | Semantics                                                         |
 | ------------- | ------ | ---------- | ----------------------------------------------------------------- |
-| `conventions` | string | MUST       | Space-separated convention identifiers; MUST include `"NZUG-1.0"` |
+| `conventions` | string | MUST       | Space-separated convention identifiers; MUST include `"NZ-1.0"` |
 
 ### Array Attributes
 
@@ -309,7 +309,7 @@ NZUG-1.0 uses standard (non-namespaced) attribute names. Only attributes that de
 
 ### Array Structural Requirements
 
-**\[NZUG addition\]** The following structural requirements apply to all arrays in a NZUG-1.0 dataset:
+**\[NZ addition\]** The following structural requirements apply to all arrays in a NZ-1.0 dataset:
 
 | Field                       | Location         | Requirement                                                                    |
 | --------------------------- | ---------------- | ------------------------------------------------------------------------------ |
@@ -318,7 +318,7 @@ NZUG-1.0 uses standard (non-namespaced) attribute names. Only attributes that de
 
 ## Naming Rules
 
-Names of arrays, groups, and attributes in NZUG-1.0 datasets:
+Names of arrays, groups, and attributes in NZ-1.0 datasets:
 
 - SHOULD begin with a letter (`A`–`Z`, `a`–`z`)
 - SHOULD consist of letters, digits, and underscores
@@ -326,29 +326,29 @@ Names of arrays, groups, and attributes in NZUG-1.0 datasets:
 - Are case-sensitive, but names that differ only by case SHOULD be avoided
 - MAY contain period (`.`) or hyphen (`-`), but these are discouraged in names intended to be referenced in attribute values
 
-These rules ensure that NZUG-1.0 names can be used unambiguously in domain convention attribute values (which reference array names as strings), in CDL text representations, and in URL path components.
+These rules ensure that NZ-1.0 names can be used unambiguously in domain convention attribute values (which reference array names as strings), in CDL text representations, and in URL path components.
 
 ## Consolidated Metadata
 
-NZUG-1.0 RECOMMENDS the use of consolidated metadata for datasets served from object storage. When consolidated metadata is present, its content MUST be consistent with the individual `zarr.json` objects it summarizes. Convention-aware readers SHOULD prefer consolidated metadata when available.
+NZ-1.0 RECOMMENDS the use of consolidated metadata for datasets served from object storage. When consolidated metadata is present, its content MUST be consistent with the individual `zarr.json` objects it summarizes. Convention-aware readers SHOULD prefer consolidated metadata when available.
 
-Consolidated metadata in Zarr v3 is implemented by zarr-python and proposed for formal standardization in [zarr-specs #309](https://github.com/zarr-developers/zarr-specs/issues/309). NZUG-1.0 adopts the zarr-python convention pending that standardization: consolidated metadata is stored in the root group `zarr.json` under the `consolidated_metadata` key. When zarr-specs #309 is finalized, this section will be updated to cite the formal specification.
+Consolidated metadata in Zarr v3 is implemented by zarr-python and proposed for formal standardization in [zarr-specs #309](https://github.com/zarr-developers/zarr-specs/issues/309). NZ-1.0 adopts the zarr-python convention pending that standardization: consolidated metadata is stored in the root group `zarr.json` under the `consolidated_metadata` key. When zarr-specs #309 is finalized, this section will be updated to cite the formal specification.
 
 ## What This Convention Enables (Informative)
 
-A domain convention written against NZUG-1.0 has access to:
+A domain convention written against NZ-1.0 has access to:
 
 - **Named, constrained dimensions.** The shared dimension constraint means that dimension labels within a group carry co-extent guarantees, enabling domain conventions to define co-location of arrays using the same semantics as netCDF.
 - **Dimension coordinates.** Identified structurally, without any additional attribute, exactly as coordinate variables are identified in the NUG.
 - **Typed attributes.** The `_nczarr_attr` type annotation mechanism (adopted from NCZarr) gives domain conventions a way to express precision requirements for numeric attributes that would otherwise be lost in JSON serialization.
 - **Semantic fill values.** `_FillValue` decoupled from the storage `fill_value`, preserving the NUG's masking semantics independently of Zarr's chunk initialization behavior.
-- **Auxiliary arrays.** The auxiliary array concept is defined structurally, enabling domain conventions to build their own coordinate association mechanisms (e.g., the `coordinates` attribute) on top of NZUG.
+- **Auxiliary arrays.** The auxiliary array concept is defined structurally, enabling domain conventions to build their own coordinate association mechanisms (e.g., the `coordinates` attribute) on top of NZ.
 
-### NUG to NZUG Mapping Table
+### NUG to NZ Mapping Table
 
-The existing CF conventions document can be applied to NZUG-1.0 datasets by substituting NZUG-1.0 structural concepts for their NUG equivalents:
+The existing CF conventions document can be applied to NZ-1.0 datasets by substituting NZ-1.0 structural concepts for their NUG equivalents:
 
-| NUG concept                     | NZUG-1.0 equivalent                                                |
+| NUG concept                     | NZ-1.0 equivalent                                                |
 | ------------------------------- | ------------------------------------------------------------------ |
 | netCDF file                     | Zarr v3 hierarchy                                                  |
 | dimension                       | dimension label in `dimension_names` + shared dimension constraint |
@@ -360,36 +360,36 @@ The existing CF conventions document can be applied to NZUG-1.0 datasets by subs
 | `_FillValue` variable attribute | `_FillValue` array attribute                                       |
 | `Conventions` global attribute  | `conventions` root group attribute                                 |
 
-No changes to the CF conventions document are required to use CF semantics with NZUG-1.0 datasets. A CF-Zarr profile document citing NZUG-1.0 performs the mapping above and declares compliance with both.
+No changes to the CF conventions document are required to use CF semantics with NZ-1.0 datasets. A CF-Zarr profile document citing NZ-1.0 performs the mapping above and declares compliance with both.
 
 ## Out of Scope (Informative)
 
-The following topics are explicitly deferred to conventions built on NZUG-1.0. They are active areas of community work in the CF, GeoZarr, and Zarr communities and are not ready for standardization at the structural interoperability layer.
+The following topics are explicitly deferred to conventions built on NZ-1.0. They are active areas of community work in the CF, GeoZarr, and Zarr communities and are not ready for standardization at the structural interoperability layer.
 
-**Coordinate reference systems.** How CRS information is encoded — whether via CF `grid_mapping`, GeoZarr `proj:` attributes, WKT2, PROJJSON, or other mechanisms — is a GeoZarr and CF community question. NZUG-1.0 reserves no CRS-related attribute names and takes no position on encoding.
+**Coordinate reference systems.** How CRS information is encoded — whether via CF `grid_mapping`, GeoZarr `proj:` attributes, WKT2, PROJJSON, or other mechanisms — is a GeoZarr and CF community question. NZ-1.0 reserves no CRS-related attribute names and takes no position on encoding.
 
-**Axis order.** The relationship between the order of entries in `dimension_names` and the axis order expressed in a CRS definition is an open problem with known silent failure modes. NZUG-1.0 does not address it.
+**Axis order.** The relationship between the order of entries in `dimension_names` and the axis order expressed in a CRS definition is an open problem with known silent failure modes. NZ-1.0 does not address it.
 
-**Coordinate role identification beyond dimension coordinates.** Whether an array is a latitude coordinate, a time coordinate, or a vertical coordinate is determined by domain conventions through mechanisms such as standard names, units, and axis attributes. NZUG-1.0 identifies only dimension coordinates structurally; all further coordinate semantics are left to domain conventions.
+**Coordinate role identification beyond dimension coordinates.** Whether an array is a latitude coordinate, a time coordinate, or a vertical coordinate is determined by domain conventions through mechanisms such as standard names, units, and axis attributes. NZ-1.0 identifies only dimension coordinates structurally; all further coordinate semantics are left to domain conventions.
 
-**Auxiliary coordinate association.** How auxiliary arrays are linked to data arrays (e.g., the `coordinates` attribute) is a domain convention concern. NZUG-1.0 defines the auxiliary array concept but does not reserve attribute names for declaring those relationships.
+**Auxiliary coordinate association.** How auxiliary arrays are linked to data arrays (e.g., the `coordinates` attribute) is a domain convention concern. NZ-1.0 defines the auxiliary array concept but does not reserve attribute names for declaring those relationships.
 
-**Data description attributes.** Attribute names for units, long names, valid ranges, packing parameters (scale_factor, add_offset), and similar descriptive metadata are defined by domain conventions such as CF, not by NZUG-1.0.
+**Data description attributes.** Attribute names for units, long names, valid ranges, packing parameters (scale_factor, add_offset), and similar descriptive metadata are defined by domain conventions such as CF, not by NZ-1.0.
 
-**Unlimited dimensions.** The NUG supports unlimited dimensions for record-oriented appending. Zarr has no equivalent concept. NZUG-1.0 does not define one.
+**Unlimited dimensions.** The NUG supports unlimited dimensions for record-oriented appending. Zarr has no equivalent concept. NZ-1.0 does not define one.
 
-**User-defined types.** Enumerated, opaque, variable-length, and compound types from the netCDF-4 enhanced data model have no Zarr v3 equivalents. NZUG-1.0 does not address them.
+**User-defined types.** Enumerated, opaque, variable-length, and compound types from the netCDF-4 enhanced data model have no Zarr v3 equivalents. NZ-1.0 does not address them.
 
 **Aggregation and virtual datasets.** Kerchunk, Icechunk, and related virtual store approaches are out of scope.
 
-**Inter-group dimension relationships.** NZUG-1.0 scopes the shared dimension constraint to within a group. Whether dimension labels carry meaning across group boundaries is left to domain conventions.
+**Inter-group dimension relationships.** NZ-1.0 scopes the shared dimension constraint to within a group. Whether dimension labels carry meaning across group boundaries is left to domain conventions.
 
 ## Normative Summary
 
-A NZUG-1.0 compliant dataset:
+A NZ-1.0 compliant dataset:
 
 1. Is a valid Zarr v3 dataset.
-2. Has `"NZUG-1.0"` in the `conventions` attribute of its root group `zarr.json`.
+2. Has `"NZ-1.0"` in the `conventions` attribute of its root group `zarr.json`.
 3. Has fully populated `dimension_names` (no `null` or empty-string entries) in every array `zarr.json`.
 4. Satisfies the shared dimension constraint: within any group, all arrays sharing a dimension label have the same length along that axis.
 5. Uses `_FillValue` in array attributes (when present) as the semantic missing data indicator, distinct from the storage `fill_value`.
@@ -399,7 +399,7 @@ A NZUG-1.0 compliant dataset:
 
 ## Appendix A: Differences from the Zarr v3 Specification
 
-| Topic                       | Zarr v3 spec                    | NZUG-1.0                                                  |
+| Topic                       | Zarr v3 spec                    | NZ-1.0                                                  |
 | --------------------------- | ------------------------------- | --------------------------------------------------------- |
 | `dimension_names`           | Optional; entries may be `null` | Required; all entries must be non-null, non-empty strings |
 | Shared dimension constraint | Not defined                     | Required within groups                                    |
@@ -410,7 +410,7 @@ A NZUG-1.0 compliant dataset:
 
 ## Appendix B: Differences from the NetCDF Users Guide
 
-| Topic                   | NUG (netCDF)                                                       | NZUG-1.0                                                                                         |
+| Topic                   | NUG (netCDF)                                                       | NZ-1.0                                                                                         |
 | ----------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
 | Dimension definition    | Declared, named, and sized; shared by structural reference in file | Label in `dimension_names`; co-extent enforced by shared dimension constraint                    |
 | Coordinate variable     | 1D variable whose name matches a dimension name                    | Array whose `dimension_names` entry matches its own name and whose values are strictly monotonic |
@@ -428,11 +428,11 @@ This section helps potential implementers assess the convention's maturity and a
 
 _No implementations yet. This convention is in the Proposal stage._
 
-The following tools already use patterns compatible with NZUG-1.0:
+The following tools already use patterns compatible with NZ-1.0:
 
-- **[netCDF-C (NCZarr)](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html)** — C library for netCDF data access. NCZarr's `_nczarr_attr` type annotation pattern is adopted by NZUG-1.0 for attribute type preservation.
+- **[netCDF-C (NCZarr)](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html)** — C library for netCDF data access. NCZarr's `_nczarr_attr` type annotation pattern is adopted by NZ-1.0 for attribute type preservation.
 - **[xarray](https://github.com/pydata/xarray)** — Python library for labeled multi-dimensional arrays. Uses `dimension_names`, `_FillValue`, and `conventions` attributes when reading/writing Zarr.
-- **[netCDF-Java](https://github.com/Unidata/netcdf-java)** — Java library for scientific data access. Implements NUG semantics that NZUG-1.0 is designed to parallel.
+- **[netCDF-Java](https://github.com/Unidata/netcdf-java)** — Java library for scientific data access. Implements NUG semantics that NZ-1.0 is designed to parallel.
 
 ### Datasets Using This Convention
 
@@ -443,7 +443,7 @@ _No datasets yet. Community contributions welcome._
 - [zarr-conventions discussions](https://github.com/orgs/zarr-conventions/discussions) — Community forum for convention development
 - [CF Metadata Conventions](https://cfconventions.org/) — Primary domain convention this spec supports
 - [Zarr v3 Specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) — Underlying format specification
-- [NetCDF Users Guide](https://docs.unidata.ucar.edu/nug/current/) — The structural reference NZUG-1.0 parallels
+- [NetCDF Users Guide](https://docs.unidata.ucar.edu/nug/current/) — The structural reference NZ-1.0 parallels
 
 _If you implement or use this convention, please add your implementation to this list by submitting a pull request._
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NZ-1.0 (NetCDF Zarr convention) is a Zarr convention that defines a structural i
 
 The primary design goal is to allow existing domain conventions — in particular the [CF Metadata Conventions](https://cfconventions.org/) — to be applied to Zarr v3 datasets by replacing the NUG as the underlying structural reference, **with no changes required to the domain convention itself.**
 
-NZ-1.0 is not a geospatial convention, not a CF extension, and not a replacement for the Zarr v3 specification. It is the structural layer between the format specification and domain conventions.
+NZ is not a geospatial convention, not a CF extension, and not a replacement for the Zarr v3 specification. It is the structural layer between the format specification and domain conventions.
 
 All properties use standard attribute names (not namespaced) and are placed at the root `attributes` level following the [Zarr Conventions Specification](https://github.com/zarr-conventions/zarr-conventions-spec).
 
@@ -44,7 +44,7 @@ All properties use standard attribute names (not namespaced) and are placed at t
 
 ### Separation of Concerns
 
-NZ-1.0 is explicitly scoped to the structural interoperability layer. The following are **out of scope** and left to conventions that build on NZ:
+NZ is explicitly scoped to the structural interoperability layer. The following are **out of scope** and left to conventions that build on NZ:
 
 - Coordinate reference systems and geospatial metadata
 - Standard names, units vocabularies, and physical quantity identification
@@ -58,15 +58,15 @@ NZ-1.0 is explicitly scoped to the structural interoperability layer. The follow
 
 ### Relationship to the Zarr v3 Specification
 
-NZ-1.0 adds normative constraints and definitions above the Zarr v3 specification. It does not modify or contradict the Zarr v3 spec. Every valid NZ-1.0 dataset is a valid Zarr v3 dataset. Implementations that support Zarr v3 can read NZ-1.0 datasets; they will simply not enforce the additional constraints defined here.
+NZ adds normative constraints and definitions above the Zarr v3 specification. It does not modify or contradict the Zarr v3 spec. Every valid NZ-1.0 dataset is a valid Zarr v3 dataset. Implementations that support Zarr v3 can read NZ-1.0 datasets; they will simply not enforce the additional constraints defined here.
 
 ### Relationship to Zarr v2
 
-NZ-1.0 is defined against Zarr v3, but its structural concepts have direct analogues in Zarr v2 datasets. Many v2 datasets already follow the patterns NZ formalizes: xarray writes dimension names via the `_ARRAY_DIMENSIONS` attribute in `.zattrs`, NCZarr writes attribute type annotations via `_nczarr_attr` in `.zattrs`, and `_FillValue` and `conventions` are widely used. A Zarr v2 dataset that follows these existing practices is structurally equivalent to a NZ-1.0 dataset, differing only in the metadata container (`.zattrs` / `.zarray` vs unified `zarr.json`) and the dimension name mechanism (`_ARRAY_DIMENSIONS` attribute vs `dimension_names` field). NZ-1.0 does not define a v2 profile, but implementations that support both format versions MAY apply NZ-1.0 structural semantics to v2 datasets that use these established patterns.
+NZ is defined against Zarr v3, but its structural concepts have direct analogues in Zarr v2 datasets. Many v2 datasets already follow the patterns NZ formalizes: xarray writes dimension names via the `_ARRAY_DIMENSIONS` attribute in `.zattrs`, NCZarr writes attribute type annotations via `_nczarr_attr` in `.zattrs`, and `_FillValue` and `conventions` are widely used. A Zarr v2 dataset that follows these existing practices is structurally equivalent to a NZ-1.0 dataset, differing only in the metadata container (`.zattrs` / `.zarray` vs unified `zarr.json`) and the dimension name mechanism (`_ARRAY_DIMENSIONS` attribute vs `dimension_names` field). NZ does not define a v2 profile, but implementations that support both format versions MAY apply NZ structural semantics to v2 datasets that use these established patterns.
 
 ### Relationship to Domain Conventions
 
-A domain convention is a document that specifies semantics for datasets built on a structural interoperability layer. The CF Metadata Conventions are the primary domain convention this document is designed to support. NZ-1.0 provides to a CF-Zarr profile exactly what the NUG provides to CF-netCDF.
+A domain convention is a document that specifies semantics for datasets built on a structural interoperability layer. The CF Metadata Conventions are the primary domain convention this document is designed to support. NZ provides to a CF-Zarr profile exactly what the NUG provides to CF-netCDF.
 
 Domain conventions built on NZ-1.0 MUST declare compliance using the `conventions` attribute defined in [Convention Declaration](#convention-declaration). They MAY add constraints above NZ-1.0 but MUST NOT contradict it. For backward compatibility, software that supports NetCDF in Zarr are encouraged to try to support data that do not declare compliance with NZ conventions but do adhere to its assumptions.
 
@@ -125,7 +125,7 @@ A dataset conforming to multiple conventions lists them space-separated, ordered
 
 The `conventions` attribute is case-insensitive for the purpose of matching convention identifiers. The `Conventions` attribute (capital C), used in the NUG, MUST be treated as equivalent to `conventions` during reading for backward compatibility with datasets produced by netCDF toolchains.
 
-> **Note:** NZ-1.0 uses the `conventions` string attribute at the root group level for declaration. This is consistent with the NUG `Conventions` attribute pattern and with how xarray and existing CF-Zarr tools already use this field. Datasets conforming to the [zarr-conventions-spec](https://github.com/zarr-conventions/zarr-conventions-spec) framework MAY additionally include a `zarr_conventions` entry per that framework.
+> **Note:** NZ uses the `conventions` string attribute at the root group level for declaration. This is consistent with the NUG `Conventions` attribute pattern and with how xarray and existing CF-Zarr tools already use this field. Datasets conforming to the [zarr-conventions-spec](https://github.com/zarr-conventions/zarr-conventions-spec) framework MAY additionally include a `zarr_conventions` entry per that framework.
 
 ## Data Model
 
@@ -147,7 +147,7 @@ A _group_ is a node with `"node_type": "group"`. Groups may contain child groups
 
 An _array_ is a node with `"node_type": "array"`. An array has a shape, a data type, a chunk grid, a codec pipeline, a fill value, and optionally dimension names and attributes, all carried in its `zarr.json`.
 
-**\[NZ addition\]** In a NZ-1.0 dataset, every array MUST have a fully populated `dimension_names` field. The `dimension_names` array MUST have the same length as `shape`. No entry in `dimension_names` may be `null` or the empty string `""`. The Zarr v3 specification makes `dimension_names` optional; NZ-1.0 requires it.
+**\[NZ addition\]** In a NZ-1.0 dataset, every array MUST have a fully populated `dimension_names` field. The `dimension_names` array MUST have the same length as `shape`. No entry in `dimension_names` may be `null` or the empty string `""`. The Zarr v3 specification makes `dimension_names` optional; NZ requires it.
 
 Example of a minimal compliant array `zarr.json`:
 
@@ -198,17 +198,17 @@ An array named `lat` with `"dimension_names": ["lat"]` and monotonically ordered
 
 ### Auxiliary Array
 
-An _auxiliary array_ is an array that provides coordinate or ancillary information for another array but does not satisfy the dimension coordinate definition above. How auxiliary arrays are associated with data arrays — including the attribute names and syntax used to declare those relationships — is left to domain conventions (e.g., the `coordinates` attribute used by CF). NZ-1.0 defines the concept but does not reserve any attribute names for it.
+An _auxiliary array_ is an array that provides coordinate or ancillary information for another array but does not satisfy the dimension coordinate definition above. How auxiliary arrays are associated with data arrays — including the attribute names and syntax used to declare those relationships — is left to domain conventions (e.g., the `coordinates` attribute used by CF). NZ defines the concept but does not reserve any attribute names for it.
 
 ### Scalar Array
 
-**\[NZ addition\]** A _scalar array_ is an array that holds exactly one value. It is encoded in Zarr v3 with `"shape": []` (no dimensions) and `"dimension_names": []`. Despite having no dimensions, a scalar array contains a single typed data value in its chunk store. NZ-1.0 requires implementations to support scalar arrays.
+**\[NZ addition\]** A _scalar array_ is an array that holds exactly one value. It is encoded in Zarr v3 with `"shape": []` (no dimensions) and `"dimension_names": []`. Despite having no dimensions, a scalar array contains a single typed data value in its chunk store. NZ requires implementations to support scalar arrays.
 
 Scalar arrays are used as single-valued coordinate variables — for example, to represent a single pressure level or forecast time without introducing a size-one dimension. They are not a substitute for attributes: a scalar array is a first-class array node with a declared `data_type` and coordinate semantics, not JSON metadata. A naive Zarr v3 reader will read scalar arrays without error.
 
 ## Type System
 
-The NUG's typed attribute model is a load-bearing feature for domain conventions. Precision requirements for numeric attributes — such as packing parameters and CRS coefficients — depend on knowing whether an attribute value is `float32` or `float64`. Zarr v3's JSON attribute model does not provide this distinction. This section defines the NZ-1.0 type system for attributes.
+The NUG's typed attribute model is a load-bearing feature for domain conventions. Precision requirements for numeric attributes — such as packing parameters and CRS coefficients — depend on knowing whether an attribute value is `float32` or `float64`. Zarr v3's JSON attribute model does not provide this distinction. This section defines the NZ type system for attributes.
 
 ### Array Data Types
 
@@ -276,11 +276,11 @@ The following table shows the correspondence between Zarr v3 type names and NC t
 | `float32`    | `NC_FLOAT`  |
 | `float64`    | `NC_DOUBLE` |
 
-> **Interoperability note:** Datasets produced by [NCZarr](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html) (netCDF-C's Zarr backend) use [NumPy dtype notation](https://numpy.org/doc/stable/reference/arrays.dtypes.html) (e.g., `<f4` for `float32`) in `_nczarr_attr` type values. NumPy dtype strings are not part of the NZ-1.0 specification, but implementations are encouraged to recognize them without error to support interoperability with NCZarr-produced datasets.
+> **Interoperability note:** Datasets produced by [NCZarr](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html) (netCDF-C's Zarr backend) use [NumPy dtype notation](https://numpy.org/doc/stable/reference/arrays.dtypes.html) (e.g., `<f4` for `float32`) in `_nczarr_attr` type values. NumPy dtype strings are not part of the NZ specification, but implementations are encouraged to recognize them without error to support interoperability with NCZarr-produced datasets.
 
-The `_nczarr_attr` object need not annotate every attribute — only those whose default JSON type is insufficient. Unannotated numeric attributes are interpreted at their JSON default type per [Attribute Value Types](#attribute-value-types). The `_nczarr_attr` attribute is reserved by NZ-1.0 and MUST NOT be used for other purposes. Implementations SHOULD suppress `_nczarr_attr` from user-visible attribute listings.
+The `_nczarr_attr` object need not annotate every attribute — only those whose default JSON type is insufficient. Unannotated numeric attributes are interpreted at their JSON default type per [Attribute Value Types](#attribute-value-types). The `_nczarr_attr` attribute is reserved by NZ and MUST NOT be used for other purposes. Implementations SHOULD suppress `_nczarr_attr` from user-visible attribute listings.
 
-This mechanism is directly interoperable with datasets produced by [netCDF-C's NCZarr backend](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html), which uses the same `_nczarr_attr` / `types` structure in Zarr v2 `.zattr` objects. NZ-1.0 places this structure in Zarr v3 `zarr.json` `attributes`.
+This mechanism is directly interoperable with datasets produced by [netCDF-C's NCZarr backend](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html), which uses the same `_nczarr_attr` / `types` structure in Zarr v2 `.zattr` objects. NZ places this structure in Zarr v3 `zarr.json` `attributes`.
 
 ### The `_FillValue` Attribute
 
@@ -292,7 +292,7 @@ This decoupling is necessary because Zarr's storage `fill_value` serves a differ
 
 ## Properties
 
-NZ-1.0 uses standard (non-namespaced) attribute names. Only attributes that define or support the structural interoperability layer are reserved here. All domain-level attributes — including those defined by CF (e.g., `units`, `long_name`, `scale_factor`, `add_offset`, `coordinates`, `valid_range`) — are left to domain conventions and are not reserved by NZ-1.0.
+NZ uses standard (non-namespaced) attribute names. Only attributes that define or support the structural interoperability layer are reserved here. All domain-level attributes — including those defined by CF (e.g., `units`, `long_name`, `scale_factor`, `add_offset`, `coordinates`, `valid_range`) — are left to domain conventions and are not reserved by NZ.
 
 ### Root Group Attributes
 
@@ -326,17 +326,17 @@ Names of arrays, groups, and attributes in NZ-1.0 datasets:
 - Are case-sensitive, but names that differ only by case SHOULD be avoided
 - MAY contain period (`.`) or hyphen (`-`), but these are discouraged in names intended to be referenced in attribute values
 
-These rules ensure that NZ-1.0 names can be used unambiguously in domain convention attribute values (which reference array names as strings), in CDL text representations, and in URL path components.
+These rules ensure that NZ names can be used unambiguously in domain convention attribute values (which reference array names as strings), in CDL text representations, and in URL path components.
 
 ## Consolidated Metadata
 
-NZ-1.0 RECOMMENDS the use of consolidated metadata for datasets served from object storage. When consolidated metadata is present, its content MUST be consistent with the individual `zarr.json` objects it summarizes. Convention-aware readers SHOULD prefer consolidated metadata when available.
+NZ RECOMMENDS the use of consolidated metadata for datasets served from object storage. When consolidated metadata is present, its content MUST be consistent with the individual `zarr.json` objects it summarizes. Convention-aware readers SHOULD prefer consolidated metadata when available.
 
-Consolidated metadata in Zarr v3 is implemented by zarr-python and proposed for formal standardization in [zarr-specs #309](https://github.com/zarr-developers/zarr-specs/issues/309). NZ-1.0 adopts the zarr-python convention pending that standardization: consolidated metadata is stored in the root group `zarr.json` under the `consolidated_metadata` key. When zarr-specs #309 is finalized, this section will be updated to cite the formal specification.
+Consolidated metadata in Zarr v3 is implemented by zarr-python and proposed for formal standardization in [zarr-specs #309](https://github.com/zarr-developers/zarr-specs/issues/309). NZ adopts the zarr-python convention pending that standardization: consolidated metadata is stored in the root group `zarr.json` under the `consolidated_metadata` key. When zarr-specs #309 is finalized, this section will be updated to cite the formal specification.
 
 ## What This Convention Enables (Informative)
 
-A domain convention written against NZ-1.0 has access to:
+A domain convention written against NZ has access to:
 
 - **Named, constrained dimensions.** The shared dimension constraint means that dimension labels within a group carry co-extent guarantees, enabling domain conventions to define co-location of arrays using the same semantics as netCDF.
 - **Dimension coordinates.** Identified structurally, without any additional attribute, exactly as coordinate variables are identified in the NUG.
@@ -346,7 +346,7 @@ A domain convention written against NZ-1.0 has access to:
 
 ### NUG to NZ Mapping Table
 
-The existing CF conventions document can be applied to NZ-1.0 datasets by substituting NZ-1.0 structural concepts for their NUG equivalents:
+The existing CF conventions document can be applied to NZ-1.0 datasets by substituting NZ structural concepts for their NUG equivalents:
 
 | NUG concept                     | NZ-1.0 equivalent                                                |
 | ------------------------------- | ------------------------------------------------------------------ |
@@ -360,29 +360,29 @@ The existing CF conventions document can be applied to NZ-1.0 datasets by substi
 | `_FillValue` variable attribute | `_FillValue` array attribute                                       |
 | `Conventions` global attribute  | `conventions` root group attribute                                 |
 
-No changes to the CF conventions document are required to use CF semantics with NZ-1.0 datasets. A CF-Zarr profile document citing NZ-1.0 performs the mapping above and declares compliance with both.
+No changes to the CF conventions document are required to use CF semantics with NZ-1.0 datasets. A CF-Zarr profile document citing NZ performs the mapping above and declares compliance with both.
 
 ## Out of Scope (Informative)
 
-The following topics are explicitly deferred to conventions built on NZ-1.0. They are active areas of community work in the CF, GeoZarr, and Zarr communities and are not ready for standardization at the structural interoperability layer.
+The following topics are explicitly deferred to conventions built on NZ. They are active areas of community work in the CF, GeoZarr, and Zarr communities and are not ready for standardization at the structural interoperability layer.
 
-**Coordinate reference systems.** How CRS information is encoded — whether via CF `grid_mapping`, GeoZarr `proj:` attributes, WKT2, PROJJSON, or other mechanisms — is a GeoZarr and CF community question. NZ-1.0 reserves no CRS-related attribute names and takes no position on encoding.
+**Coordinate reference systems.** How CRS information is encoded — whether via CF `grid_mapping`, GeoZarr `proj:` attributes, WKT2, PROJJSON, or other mechanisms — is a GeoZarr and CF community question. NZ reserves no CRS-related attribute names and takes no position on encoding.
 
-**Axis order.** The relationship between the order of entries in `dimension_names` and the axis order expressed in a CRS definition is an open problem with known silent failure modes. NZ-1.0 does not address it.
+**Axis order.** The relationship between the order of entries in `dimension_names` and the axis order expressed in a CRS definition is an open problem with known silent failure modes. NZ does not address it.
 
-**Coordinate role identification beyond dimension coordinates.** Whether an array is a latitude coordinate, a time coordinate, or a vertical coordinate is determined by domain conventions through mechanisms such as standard names, units, and axis attributes. NZ-1.0 identifies only dimension coordinates structurally; all further coordinate semantics are left to domain conventions.
+**Coordinate role identification beyond dimension coordinates.** Whether an array is a latitude coordinate, a time coordinate, or a vertical coordinate is determined by domain conventions through mechanisms such as standard names, units, and axis attributes. NZ identifies only dimension coordinates structurally; all further coordinate semantics are left to domain conventions.
 
-**Auxiliary coordinate association.** How auxiliary arrays are linked to data arrays (e.g., the `coordinates` attribute) is a domain convention concern. NZ-1.0 defines the auxiliary array concept but does not reserve attribute names for declaring those relationships.
+**Auxiliary coordinate association.** How auxiliary arrays are linked to data arrays (e.g., the `coordinates` attribute) is a domain convention concern. NZ defines the auxiliary array concept but does not reserve attribute names for declaring those relationships.
 
-**Data description attributes.** Attribute names for units, long names, valid ranges, packing parameters (scale_factor, add_offset), and similar descriptive metadata are defined by domain conventions such as CF, not by NZ-1.0.
+**Data description attributes.** Attribute names for units, long names, valid ranges, packing parameters (scale_factor, add_offset), and similar descriptive metadata are defined by domain conventions such as CF, not by NZ.
 
-**Unlimited dimensions.** The NUG supports unlimited dimensions for record-oriented appending. Zarr has no equivalent concept. NZ-1.0 does not define one.
+**Unlimited dimensions.** The NUG supports unlimited dimensions for record-oriented appending. Zarr has no equivalent concept. NZ does not define one.
 
-**User-defined types.** Enumerated, opaque, variable-length, and compound types from the netCDF-4 enhanced data model have no Zarr v3 equivalents. NZ-1.0 does not address them.
+**User-defined types.** Enumerated, opaque, variable-length, and compound types from the netCDF-4 enhanced data model have no Zarr v3 equivalents. NZ does not address them.
 
 **Aggregation and virtual datasets.** Kerchunk, Icechunk, and related virtual store approaches are out of scope.
 
-**Inter-group dimension relationships.** NZ-1.0 scopes the shared dimension constraint to within a group. Whether dimension labels carry meaning across group boundaries is left to domain conventions.
+**Inter-group dimension relationships.** NZ scopes the shared dimension constraint to within a group. Whether dimension labels carry meaning across group boundaries is left to domain conventions.
 
 ## Normative Summary
 
@@ -428,11 +428,11 @@ This section helps potential implementers assess the convention's maturity and a
 
 _No implementations yet. This convention is in the Proposal stage._
 
-The following tools already use patterns compatible with NZ-1.0:
+The following tools already use patterns compatible with NZ:
 
-- **[netCDF-C (NCZarr)](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html)** — C library for netCDF data access. NCZarr's `_nczarr_attr` type annotation pattern is adopted by NZ-1.0 for attribute type preservation.
+- **[netCDF-C (NCZarr)](https://docs.unidata.ucar.edu/netcdf-c/current/nczarr_head.html)** — C library for netCDF data access. NCZarr's `_nczarr_attr` type annotation pattern is adopted by NZ for attribute type preservation.
 - **[xarray](https://github.com/pydata/xarray)** — Python library for labeled multi-dimensional arrays. Uses `dimension_names`, `_FillValue`, and `conventions` attributes when reading/writing Zarr.
-- **[netCDF-Java](https://github.com/Unidata/netcdf-java)** — Java library for scientific data access. Implements NUG semantics that NZ-1.0 is designed to parallel.
+- **[netCDF-Java](https://github.com/Unidata/netcdf-java)** — Java library for scientific data access. Implements NUG semantics that NZ is designed to parallel.
 
 ### Datasets Using This Convention
 
@@ -443,7 +443,7 @@ _No datasets yet. Community contributions welcome._
 - [zarr-conventions discussions](https://github.com/orgs/zarr-conventions/discussions) — Community forum for convention development
 - [CF Metadata Conventions](https://cfconventions.org/) — Primary domain convention this spec supports
 - [Zarr v3 Specification](https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html) — Underlying format specification
-- [NetCDF Users Guide](https://docs.unidata.ucar.edu/nug/current/) — The structural reference NZ-1.0 parallels
+- [NetCDF Users Guide](https://docs.unidata.ucar.edu/nug/current/) — The structural reference NZ parallels
 
 _If you implement or use this convention, please add your implementation to this list by submitting a pull request._
 

--- a/examples/array_basic.json
+++ b/examples/array_basic.json
@@ -20,10 +20,10 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
         "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-        "name": "NZUG-1.0",
+        "name": "NZ-1.0",
         "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
       }
     ]

--- a/examples/array_fillvalue.json
+++ b/examples/array_fillvalue.json
@@ -20,10 +20,10 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
         "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-        "name": "NZUG-1.0",
+        "name": "NZ-1.0",
         "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
       }
     ],

--- a/examples/array_typed_attrs.json
+++ b/examples/array_typed_attrs.json
@@ -20,10 +20,10 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
         "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-        "name": "NZUG-1.0",
+        "name": "NZ-1.0",
         "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
       }
     ],

--- a/examples/dimension_coordinate.json
+++ b/examples/dimension_coordinate.json
@@ -17,10 +17,10 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
         "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-        "name": "NZUG-1.0",
+        "name": "NZ-1.0",
         "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
       }
     ]

--- a/examples/root_group.json
+++ b/examples/root_group.json
@@ -12,6 +12,6 @@
       }
     ],
     "conventions": "NZ-1.0",
-    "title": "Example NZ-1.0 dataset"
+    "title": "Example NZ dataset"
   }
 }

--- a/examples/root_group.json
+++ b/examples/root_group.json
@@ -4,14 +4,14 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
         "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-        "name": "NZUG-1.0",
+        "name": "NZ-1.0",
         "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
       }
     ],
-    "conventions": "NZUG-1.0",
-    "title": "Example NZUG-1.0 dataset"
+    "conventions": "NZ-1.0",
+    "title": "Example NZ-1.0 dataset"
   }
 }

--- a/examples/root_group_cf.json
+++ b/examples/root_group_cf.json
@@ -4,14 +4,14 @@
   "attributes": {
     "zarr_conventions": [
       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
         "uuid": "d0a980b5-c644-4dcc-85a1-283799a58f40",
-        "name": "NZUG-1.0",
+        "name": "NZ-1.0",
         "description": "Structural interoperability layer for scientific array conventions on Zarr v3"
       }
     ],
-    "conventions": "NZUG-1.0 CF-1.12",
+    "conventions": "NZ-1.0 CF-1.12",
     "title": "ERA5 hourly data on single levels",
     "institution": "European Centre for Medium-Range Weather Forecasts",
     "source": "ERA5 reanalysis",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "zarr-convention-nzug",
+  "name": "zarr-convention-nz",
   "version": "1.0.0-draft",
   "scripts": {
     "test": "node test.js",

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "title": "NZUG-1.0 Convention",
-  "description": "Schema for NZUG-1.0 (NetCDF Zarr Users Guide) convention — structural interoperability layer for scientific array conventions on Zarr v3",
+  "title": "NZ-1.0 Convention",
+  "description": "Schema for NZ-1.0 (NetCDF Zarr convention) convention — structural interoperability layer for scientific array conventions on Zarr v3",
   "type": "object",
   "properties": {
     "zarr_format": {
@@ -56,16 +56,16 @@
   "$defs": {
     "conventionMetadata": {
       "type": "object",
-      "description": "NZUG-1.0 convention metadata object for use in zarr_conventions array",
+      "description": "NZ-1.0 convention metadata object for use in zarr_conventions array",
       "properties": {
         "schema_url": {
           "type": "string",
-          "const": "https://raw.githubusercontent.com/zarr-conventions/nzug/refs/tags/v1/schema.json",
+          "const": "https://raw.githubusercontent.com/zarr-conventions/nz/refs/tags/v1/schema.json",
           "description": "URL to the JSON Schema definition for this convention"
         },
         "spec_url": {
           "type": "string",
-          "const": "https://github.com/zarr-conventions/nzug/blob/v1/README.md",
+          "const": "https://github.com/zarr-conventions/nz/blob/v1/README.md",
           "description": "URL to the full specification document"
         },
         "uuid": {
@@ -75,7 +75,7 @@
         },
         "name": {
           "type": "string",
-          "const": "NZUG-1.0",
+          "const": "NZ-1.0",
           "description": "Human-readable name of the convention"
         },
         "description": {
@@ -126,15 +126,15 @@
     },
     "groupRequirements": {
       "type": "object",
-      "description": "Requirements specific to group nodes in NZUG-1.0",
+      "description": "Requirements specific to group nodes in NZ-1.0",
       "properties": {
         "attributes": {
           "type": "object",
           "properties": {
             "conventions": {
               "type": "string",
-              "pattern": "NZUG-1\\.0",
-              "description": "Space-separated convention identifiers; MUST include NZUG-1.0"
+              "pattern": "NZ-1\\.0",
+              "description": "Space-separated convention identifiers; MUST include NZ-1.0"
             },
             "_nczarr_attr": {
               "$ref": "#/$defs/nczarrAttr"
@@ -146,7 +146,7 @@
     },
     "arrayRequirements": {
       "type": "object",
-      "description": "Requirements specific to array nodes in NZUG-1.0",
+      "description": "Requirements specific to array nodes in NZ-1.0",
       "properties": {
         "shape": {
           "type": "array",

--- a/schema.json
+++ b/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "NZ-1.0 Convention",
-  "description": "Schema for NZ-1.0 (NetCDF Zarr convention) convention — structural interoperability layer for scientific array conventions on Zarr v3",
+  "description": "Schema for NZ (NetCDF Zarr convention) — structural interoperability layer for scientific array conventions on Zarr v3",
   "type": "object",
   "properties": {
     "zarr_format": {
@@ -56,7 +56,7 @@
   "$defs": {
     "conventionMetadata": {
       "type": "object",
-      "description": "NZ-1.0 convention metadata object for use in zarr_conventions array",
+      "description": "NZ convention metadata object for use in zarr_conventions array",
       "properties": {
         "schema_url": {
           "type": "string",
@@ -126,7 +126,7 @@
     },
     "groupRequirements": {
       "type": "object",
-      "description": "Requirements specific to group nodes in NZ-1.0",
+      "description": "Requirements specific to group nodes in NZ",
       "properties": {
         "attributes": {
           "type": "object",
@@ -146,7 +146,7 @@
     },
     "arrayRequirements": {
       "type": "object",
-      "description": "Requirements specific to array nodes in NZ-1.0",
+      "description": "Requirements specific to array nodes in NZ",
       "properties": {
         "shape": {
           "type": "array",


### PR DESCRIPTION
@maxrjones -- I went ahead and made the change. Removing "UG" is the right thing to do and I am happy with this. With you 👍 I'll merge and update the project slug.